### PR TITLE
Adds a custom lua item that can store manually marked locations

### DIFF
--- a/scripts/custom_items/manual_marked_storage.lua
+++ b/scripts/custom_items/manual_marked_storage.lua
@@ -1,0 +1,62 @@
+local function SaveManualLocationStorageFunc(self) -- executed on pack close or during export for each item
+    return {
+        MANUAL_LOCATIONS = self.ItemState.MANUAL_LOCATIONS,
+        MANUAL_LOCATIONS_ORDER = self.ItemState.MANUAL_LOCATIONS_ORDER,
+        Name = self.Name,
+        Icon = self.Icon
+    }
+end
+
+local function LoadManualLocationStorageFunc(self, data) --executed on pack load
+    if data ~= nil and self.Name == data.Name then
+        self.ItemState.MANUAL_LOCATIONS = data.MANUAL_LOCATIONS
+        self.ItemState.MANUAL_LOCATIONS_ORDER = data.MANUAL_LOCATIONS_ORDER
+        self.Icon = ImageReference:FromPackRelativePath(data.Icon)
+    else
+    end
+end
+
+local function OnLeftClickFunc(self)
+end
+local function OnRightClickFunc(self)
+end
+local function OnMiddleClickFunc(self)
+end
+
+local function CanProvideCodeFunc(self, code)
+    return code == self.Name
+end
+
+local function ProvidesCodeFunc(self, code)
+    if CanProvideCodeFunc(self, code) then
+        return 1
+    end
+    return 0
+end
+
+function CreateLuaManualLocationStorage(name)
+    local self = ScriptHost:CreateLuaItem()
+    
+    self.Name = name --code --
+    self.Icon = ImageReference:FromPackRelativePath("/images/items/closed_Chest.png")
+    self.ItemState = {
+        MANUAL_LOCATIONS = {
+            ["default"] = {}
+        },
+        MANUAL_LOCATIONS_ORDER = {}
+    }
+   
+    self.CanProvideCodeFunc = CanProvideCodeFunc
+    self.OnLeftClickFunc = OnLeftClickFunc
+    self.OnRightClickFunc = OnRightClickFunc
+    self.OnMiddleClickFunc = OnMiddleClickFunc
+    self.ProvidesCodeFunc = ProvidesCodeFunc
+    -- self.AdvanceToCodeFunc = AdvanceToCodeFunc
+    self.SaveFunc = SaveManualLocationStorageFunc
+    self.LoadFunc = LoadManualLocationStorageFunc
+    -- self.PropertyChangedFunc = PropertyChangedFunc
+    -- self.ItemState = ItemState
+    return self
+end
+
+CreateLuaManualLocationStorage("manual_location_storage")

--- a/scripts/init.lua
+++ b/scripts/init.lua
@@ -22,6 +22,7 @@ ScriptHost:LoadScript("scripts/logic/logic.lua")
 ScriptHost:LoadScript("scripts/custom_items/class.lua")
 ScriptHost:LoadScript("scripts/custom_items/progressiveTogglePlus.lua")
 ScriptHost:LoadScript("scripts/custom_items/progressiveTogglePlusWrapper.lua")
+ScriptHost:LoadScript("scripts/custom_items/manual_marked_storage.lua")
 
 -- Items
 Tracker:AddItems("items/items.jsonc")
@@ -42,3 +43,5 @@ Tracker:AddLayouts("layouts/broadcast.jsonc")
 if PopVersion and PopVersion >= "0.18.0" then
     ScriptHost:LoadScript("scripts/autotracking.lua")
 end
+
+ScriptHost:AddOnLocationSectionChangedHandler("location_section_change_handler", LocationHandler)

--- a/scripts/logic/logic.lua
+++ b/scripts/logic/logic.lua
@@ -13,3 +13,26 @@ function has_more_then_n_consumable(n)
     end
     return 0 -- 0 => no access
 end
+
+-- handler function for the custom lua item that stores manually marked off locations
+function LocationHandler(location)
+    if MANUAL_CHECKED then
+        local custom_storage_item = Tracker:FindObjectForCode("manual_location_storage")
+        if not custom_storage_item then
+            return
+        end
+        if Archipelago.PlayerNumber == -1 then -- not connected
+            if ROOM_SEED ~= "default" then -- seed is from previous connection
+                ROOM_SEED = "default"
+                custom_storage_item.ItemState.MANUAL_LOCATIONS["default"] = {}
+            else -- seed is default
+            end
+        end
+        local full_path = location.FullID
+        if location.AvailableChestCount < location.ChestCount then --add to list
+            custom_storage_item.ItemState.MANUAL_LOCATIONS[ROOM_SEED][full_path] = location.AvailableChestCount
+        else --remove from list or set back to max chestcount
+            custom_storage_item.ItemState.MANUAL_LOCATIONS[ROOM_SEED][full_path] = nil
+        end
+    end
+end


### PR DESCRIPTION
 Adds a custom lua item that can store manually marked locations (not hosted items) for up to 10 seeds and restores them upon connecting back to the same room/seed.

build its own identifier for PopTracker versions < 0.33.0 gets room seed for version 0.33.0+